### PR TITLE
replace ActuallyTaylor with OpenJelly, add missing slashes to URLs, correct minor typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ All types of contributions are encouraged and valued. See the [Table of Contents
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[Open Jellycuts Code of Conduct](https://github.com/ActuallyTaylor/Open-Jellycutsblob/master/CODE_OF_CONDUCT.md).
+[Open Jellycuts Code of Conduct](https://github.com/OpenJelly/Open-Jellycuts/blob/master/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to <jellycuts@gmaill.com>.
 
@@ -38,11 +38,11 @@ to <jellycuts@gmaill.com>.
 
 <!-- > Documentation for the main app needs to be created. If you want to ask a question, we assume that you have read the available [Documentation](https://jellycuts.com/). -->
 
-Before you ask a question, it is best to search for existing [Issues](https://github.com/ActuallyTaylor/Open-Jellycuts/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
+Before you ask a question, it is best to search for existing [Issues](https://github.com/OpenJelly/Open-Jellycuts/issues) that might help you. In case you have found a suitable issue and still need clarification, you can write your question in this issue. It is also advisable to search the internet for answers first.
 
 If you then still feel the need to ask a question and need clarification, we recommend the following:
 
-- Open an [Issue](https://github.com/ActuallyTaylor/Open-Jellycuts/issues/new).
+- Open an [Issue](https://github.com/OpenJelly/Open-Jellycuts/issues/new).
 - Provide as much context as you can about what you're running into.
 - Provide project and platform versions (nodejs, npm, etc), depending on what seems relevant.
 
@@ -66,7 +66,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 - Make sure that you are using the latest version.
 - Determine if your bug is really a bug and not an error on your side e.g. using incompatible environment components/versions (Make sure that you have read the [documentation](https://jellycuts.com/). If you are looking for support, you might want to check [this section](#i-have-a-question)).
-- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/ActuallyTaylor/Open-Jellycutsissues?q=label%3Abug).
+- To see if other users have experienced (and potentially already solved) the same issue you are having, check if there is not already a bug report existing for your bug or error in the [bug tracker](https://github.com/OpenJelly/Open-Jellycuts/issues?q=label%3Abug).
 - Also make sure to search the internet (including Stack Overflow) to see if users outside of the GitHub community have discussed the issue.
 - Collect information about the bug:
   - Stack trace (Traceback)
@@ -83,7 +83,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:
 
-- Open an [Issue](https://github.com/ActuallyTaylor/Open-Jellycuts/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
+- Open an [Issue](https://github.com/OpenJelly/Open-Jellycuts/issues/new). (Since we can't be sure at this point whether it is a bug or not, we ask you not to talk about a bug yet and not to label the issue.)
 - Explain the behavior you would expect and the actual behavior.
 - Please provide as much context as possible and describe the *reproduction steps* that someone else can follow to recreate the issue on their own. This usually includes your code. For good bug reports you should isolate the problem and create a reduced test case.
 - Provide the information you collected in the previous section.
@@ -104,13 +104,13 @@ This section guides you through submitting an enhancement suggestion for Open Je
 
 - Make sure that you are using the latest version.
 <!-- - Read the [documentation](https://jellycuts.com/) carefully and find out if the functionality is already covered, maybe by an individual configuration. -->
-- Perform a [search](https://github.com/ActuallyTaylor/Open-Jellycuts/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+- Perform a [search](https://github.com/OpenJelly/Open-Jellycuts/issues) to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 - Find out whether your idea fits with the scope and aims of the project. It's up to you to make a strong case to convince the project's developers of the merits of this feature. Keep in mind that we want features that will be useful to the majority of our users and not just a small subset. If you're just targeting a minority of users, consider writing an add-on/plugin library.
 
 <!-- omit in toc -->
 #### How Do I Submit a Good Enhancement Suggestion?
 
-Enhancement suggestions are tracked as [GitHub issues](https://github.com/ActuallyTaylor/Open-Jellycuts/issues).
+Enhancement suggestions are tracked as [GitHub issues](https://github.com/OpenJelly/Open-Jellycuts/issues).
 
 - Use a **clear and descriptive title** for the issue to identify the suggestion.
 - Provide a **step-by-step description of the suggested enhancement** in as many details as possible.
@@ -126,16 +126,16 @@ The first steps in contributing to Open Jellycuts is getting the repository runn
 #### Cloning the repository using the Terminal
 To correctly clone the repository it is **VERY** important that you use the `--recursive` flag when using the `git clone` command. This will ensure that all of the correct submodules are cloned.
 ```
-git clone --recursive https://github.com/ActuallyTaylor/Open-Jellycuts.git
+git clone --recursive https://github.com/OpenJelly/Open-Jellycuts.git
 ``` 
 
 #### Cloning using a Git Client
-A git client should be able to just take the url `https://github.com/ActuallyTaylor/Open-Jellycuts` and properly clone all of the submodules. If you are missing submodules we recommend that you use the command line to clone instead of a client.
+A git client should be able to just take the url `https://github.com/OpenJelly/Open-Jellycuts` and properly clone all of the submodules. If you are missing submodules we recommend that you use the command line to clone instead of a client.
 
 #### Setting up Xcode
 This project is meant to be used with [Apple's Xcode IDE](https://developer.apple.com/xcode/). After you have cloned the repository your next step should be to open the Xcode project in the cloned directory. This will begin cloning all of the Swift Packages used by the project, this may take some time depending on your network so give it some time.
 
-After you have cloned all of the Swift Packages the next step is too change the team identifier and bundle identifier in the signing page of the project settings. You should set these to your own values otherwise the project will not build on your system.
+After you have cloned all of the Swift Packages the next step is to change the team identifier and bundle identifier in the signing page of the project settings. You should set these to your own values otherwise the project will not build on your system.
 
 #### Adding a Key Provider
 After you have cloned the repository and set up Xcode, you will see a build error. This error is caused by the PurchaseHandler not having a provided publicKey. This code is initially commented out because the file is a secondary file to an internal file that provides the App Store validation with a public key for verifying results from the server. 
@@ -153,10 +153,10 @@ extension PurchaseHandler: PublicKeyProvider {
 #### Now write your enhancement or fix that bug!
 It is now time to write code! Everything should be compiling and signing correctly if you have followed the above steps.
 
-- If you had any issues throughout this process open an [Issue](https://github.com/ActuallyTaylor/Open-Jellycuts/issues/new) and one of the maintainers will help you get everything resolved!
+- If you had any issues throughout this process open an [Issue](https://github.com/OpenJelly/Open-Jellycuts/issues/new) and one of the maintainers will help you get everything resolved!
 
 ### Improving The Documentation
-Currently Open-Jellycuts does not have any documentation. If you want to create some, Awesome! Currently the sister project [Open Jellycore](https://github.com/ActuallyTaylor/Open-Jellycore) uses the [DocC](https://developer.apple.com/documentation/docc) documentation generation tool. Setting up DocC is fairly straightforward, the main part of documentation comes from adding documentation comments above all classes, structs and functions throughout the app.
+Currently Open-Jellycuts does not have any documentation. If you want to create some, Awesome! Currently the sister project [Open Jellycore](https://github.com/OpenJelly/Open-Jellycore) uses the [DocC](https://developer.apple.com/documentation/docc) documentation generation tool. Setting up DocC is fairly straightforward, the main part of documentation comes from adding documentation comments above all classes, structs and functions throughout the app.
 
 ## Styleguides
 ### Commit Messages


### PR DESCRIPTION
references to github.com/ActuallyTaylor were replaced by references to github.com/OpenJelly
a couple of URL in the orginal had typos in URLs that were corrected by adding a missing slash character
 line 32
 line 69
a minor typo of the word 'too' was replace by 'to'
 line 138